### PR TITLE
S3cmd

### DIFF
--- a/cd-efs/recipes/s3backup.rb
+++ b/cd-efs/recipes/s3backup.rb
@@ -7,7 +7,7 @@ template '/root/efs-backup.sh' do
   group 'root'
   mode '0744'
   variables({
-    :filesystems => node['filesystems']
+    :filesystems => node['efs_mounts']
   })
   action :create
 end

--- a/cd-efs/recipes/s3backup.rb
+++ b/cd-efs/recipes/s3backup.rb
@@ -14,7 +14,9 @@ end
 
 #See existing jobs: cat /var/spool/cron/crontabs/root
 cron "backup-efs" do
-  minute '*/5'
+  minute '0'
+  hour '4'
+  day '*'
   home '/root'
   command "/root/efs-backup.sh"
 end

--- a/cd-efs/recipes/s3backup.rb
+++ b/cd-efs/recipes/s3backup.rb
@@ -1,13 +1,26 @@
 
+package 's3cmd'
+
+template '/root/efs-backup.sh' do
+  source 's3backup/efs-backup.sh.erb'
+  owner 'root'
+  group 'root'
+  mode '0744'
+  variables({
+    :filesystems => node['filesystems']
+  })
+  action :create
+end
+
 node['filesystems'].each do |group|
 
   group['mounts'].each do |efs|
 
     cron "backup-#{efs['efs_id']}" do
-      minute '*/2'
+      minute '*/5'
       home '/'
       command %W{
-        ls -al /mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']} >> /var/log/efs-backup.log
+        ls -al /mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']} >> /var/log/efs-backup.log &&
         date >> /var/log/efs-backup.log
       }.join(' ')
     end

--- a/cd-efs/recipes/s3backup.rb
+++ b/cd-efs/recipes/s3backup.rb
@@ -12,24 +12,10 @@ template '/root/efs-backup.sh' do
   action :create
 end
 
+#See existing jobs: cat /var/spool/cron/crontabs/root
 cron "backup-efs" do
   minute '*/5'
   home '/root'
   command "/root/efs-backup.sh"
 end
 
-node['filesystems'].each do |group|
-
-  group['mounts'].each do |efs|
-
-    cron "backup-#{efs['efs_id']}" do
-      action 'delete'
-      minute '*/5'
-      home '/'
-      command "/root/efs-backup.sh"
-    end
-    # "/mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']}"
-
-  end
-
-end

--- a/cd-efs/recipes/s3backup.rb
+++ b/cd-efs/recipes/s3backup.rb
@@ -1,0 +1,18 @@
+
+node['filesystems'].each do |group|
+
+  group['mounts'].each do |efs|
+
+    cron "backup-#{efs['efs_id']}" do
+      minute '*/2'
+      home '/'
+      command %W{
+        ls -al /mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']} >> /var/log/efs-backup.log
+        date >> /var/log/efs-backup.log
+      }.join(' ')
+    end
+    # "/mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']}"
+
+  end
+
+end

--- a/cd-efs/recipes/s3backup.rb
+++ b/cd-efs/recipes/s3backup.rb
@@ -12,11 +12,18 @@ template '/root/efs-backup.sh' do
   action :create
 end
 
+cron "backup-efs" do
+  minute '*/5'
+  home '/root'
+  command "/root/efs-backup.sh"
+end
+
 node['filesystems'].each do |group|
 
   group['mounts'].each do |efs|
 
     cron "backup-#{efs['efs_id']}" do
+      action 'delete'
       minute '*/5'
       home '/'
       command "/root/efs-backup.sh"

--- a/cd-efs/recipes/s3backup.rb
+++ b/cd-efs/recipes/s3backup.rb
@@ -19,10 +19,7 @@ node['filesystems'].each do |group|
     cron "backup-#{efs['efs_id']}" do
       minute '*/5'
       home '/'
-      command %W{
-        ls -al /mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']} >> /var/log/efs-backup.log &&
-        date >> /var/log/efs-backup.log
-      }.join(' ')
+      command "/root/efs-backup.sh"
     end
     # "/mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']}"
 

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -1,20 +1,30 @@
 #/bin/bash
 exec >> /var/log/efs-backup.log
 exec 2>&1
-
+echo "BEGIN EFS BACKUP: `date`"
+# "efs_mounts": [
+#   {
+#     "mount_path": "/mnt/ca-integrations/boomi-test",
+#     "efs_id": "fs-ab74bde2",
+#     "backup_s3bucket_name": "cu-cloud-devops-boomi",
+#     "backup_s3bucket_prefix:": "efs-backups"
+#   }
+# ]
 <%
-@filesystems.each do |group|
-  group['mounts'].each do |efs|
-    src = "/mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']}/"
-    bucket_name = efs['backup_bucket_name']
-    dest = "s3://#{bucket_name}/#{efs['efs_id']}/"
-    logfile = src + 'efs-backup.log'
+@filesystems.each do |backup|
+    bucket_name = backup['backup_s3bucket_name']
     next if bucket_name.empty?
+
+    src = "#{backup['mount_path']}/"
+    prefix = backup['backup_s3bucket_prefix']
+    dest = "s3://#{bucket_name}/#{prefix}/#{efs['efs_id']}/"
+    logfile = src + 'efs-backup.log'
 %>
 # <%= src %> ==> <%= dest %>
 TMPFILE=`mktemp`
 echo "BEGIN SYNC: `date`" > $TMPFILE
 s3cmd sync --dry-run --verbose --ssl --check-md5 --delete-removed --preserve <%= src %> <%= dest%> >> $TMPFILE 2>&1
+echo "END SYNC: `date`" > $TMPFILE
 cat $TMPFILE >> <%= logfile %>
 rm $TMPFILE
 s3cmd put --dry-run --verbose --ssl --preserve <%= logfile %> <%= dest%>
@@ -23,3 +33,4 @@ s3cmd put --dry-run --verbose --ssl --preserve <%= logfile %> <%= dest%>
   end
 end
 %>
+echo "END EFS BACKUP: `date`"

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -12,13 +12,13 @@ echo "BEGIN EFS BACKUP: `date`"
 # ]
 <%
 @filesystems.each do |backup|
-    bucket_name = backup['backup_s3bucket_name']
-    next if bucket_name.empty?
+  bucket_name = backup['backup_s3bucket_name']
+  next if bucket_name.empty?
 
-    src = "#{backup['mount_path']}/"
-    prefix = backup['backup_s3bucket_prefix']
-    dest = "s3://#{bucket_name}/#{prefix}/#{efs['efs_id']}/"
-    logfile = src + 'efs-backup.log'
+  src = "#{backup['mount_path']}/"
+  prefix = backup['backup_s3bucket_prefix']
+  dest = "s3://#{bucket_name}/#{prefix}/#{efs['efs_id']}/"
+  logfile = src + 'efs-backup.log'
 %>
 # <%= src %> ==> <%= dest %>
 TMPFILE=`mktemp`
@@ -30,7 +30,6 @@ rm $TMPFILE
 s3cmd put --dry-run --verbose --ssl --preserve <%= logfile %> <%= dest%>
 
 <%
-  end
 end
 %>
 echo "END EFS BACKUP: `date`"

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -2,18 +2,18 @@
 exec >> /var/log/efs-backup.log
 exec 2>&1
 
-BUCKET_NAME=cu-cs-efs-backup-test
-
 <%
 @filesystems.each do |group|
   group['mounts'].each do |efs|
     src = "/mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']}/"
-    dest = "s3://$BUCKET_NAME/#{efs['efs_id']}/"
+    bucket_name = efs['backup_bucket_name']
+    dest = "s3://#{bucket_name}/#{efs['efs_id']}/"
     logfile = src + 'efs-backup.log'
 %>
-# <%= src %>
+# <%= src %> ==> <%= dest %>
 TMPFILE=`mktemp`
-s3cmd sync --dry-run --verbose --ssl --check-md5 --delete-removed --preserve <%= src %> <%= dest%> > $TMPFILE
+echo "BEGIN SYNC: `date`" > $TMPFILE
+s3cmd sync --dry-run --verbose --ssl --check-md5 --delete-removed --preserve <%= src %> <%= dest%> 2>&1 $TMPFILE
 cat $TMPFILE >> <%= logfile %>
 rm $TMPFILE
 s3cmd put --dry-run --verbose --ssl --preserve <%= logfile %> <%= dest%>

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -16,8 +16,7 @@ echo "BEGIN EFS BACKUP: `date`"
   next if bucket_name.empty?
 
   src = "#{backup['mount_path']}/"
-  prefix = backup['backup_s3bucket_prefix']
-  dest = "s3://#{bucket_name}/#{prefix}/#{backup['efs_id']}/"
+  dest = "s3://#{bucket_name}/#{backup['backup_s3bucket_prefix']}/#{backup['efs_id']}/"
   logfile = src + 'efs-backup.log'
 %>
 # <%= src %> ==> <%= dest %>

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -1,0 +1,12 @@
+#/bin/bash
+
+# This is a test
+
+<%
+@filesystems.each do |group|
+  group['mounts'].each do |efs| %>
+# <%= "/mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']}" %>
+<%
+  end
+end
+%>

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -23,7 +23,7 @@ echo "BEGIN EFS BACKUP: `date`"
 TMPFILE=`mktemp`
 echo "BEGIN SYNC: `date`" > $TMPFILE
 s3cmd sync --dry-run --verbose --ssl --check-md5 --delete-removed --preserve <%= src %> <%= dest%> >> $TMPFILE 2>&1
-echo "END SYNC: `date`" > $TMPFILE
+echo "END SYNC: `date`" >> $TMPFILE
 cat $TMPFILE >> <%= logfile %>
 rm $TMPFILE
 s3cmd put --dry-run --verbose --ssl --preserve <%= logfile %> <%= dest%>

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -2,14 +2,16 @@
 exec >> /var/log/efs-backup.log
 exec 2>&1
 
+BUCKET_NAME=cu-cs-efs-backup-test
+
 <%
 @filesystems.each do |group|
   group['mounts'].each do |efs|
-    src = "/mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']}"
-    efsid = "#{efs['efs_id']}"
+    src = "/mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']}/"
+    dest = "s3://$BUCKET_NAME/#{efs['efs_id']}/"
 %>
 # <%= src %>
-# s3cmd sync --verbose --dry-run <%= src %> s3://cu-cs-efs-backup-test/<%= efsid %>
+s3cmd sync --verbose --dry-run <%= src %> <%= dest%>
 <%
   end
 end

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -9,9 +9,15 @@ BUCKET_NAME=cu-cs-efs-backup-test
   group['mounts'].each do |efs|
     src = "/mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']}/"
     dest = "s3://$BUCKET_NAME/#{efs['efs_id']}/"
+    logfile = src + 'efs-backup.log'
 %>
 # <%= src %>
-s3cmd sync --verbose --dry-run <%= src %> <%= dest%>
+TMPFILE=`mktemp`
+s3cmd sync --dry-run --verbose --ssl --check-md5 --delete-removed --preserve <%= src %> <%= dest%> > $TMPFILE
+cat $TMPFILE >> <%= logfile %>
+rm $TMPFILE
+s3cmd put --dry-run --verbose --ssl --preserve <%= logfile %> <%= dest%>
+
 <%
   end
 end

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -1,11 +1,15 @@
 #/bin/bash
-
-# This is a test
+exec >> /var/log/efs-backup.log
+exec 2>&1
 
 <%
 @filesystems.each do |group|
-  group['mounts'].each do |efs| %>
-# <%= "/mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']}" %>
+  group['mounts'].each do |efs|
+    src = "/mnt/#{group['ad_group_dir_name']}/#{efs['mount_dir_name']}"
+    efsid = "#{efs['efs_id']}"
+%>
+# <%= src %>
+# s3cmd sync --verbose --dry-run <%= src %> s3://cu-cs-efs-backup-test/<%= efsid %>
 <%
   end
 end

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -9,6 +9,7 @@ exec 2>&1
     bucket_name = efs['backup_bucket_name']
     dest = "s3://#{bucket_name}/#{efs['efs_id']}/"
     logfile = src + 'efs-backup.log'
+    next if bucket_name.empty?
 %>
 # <%= src %> ==> <%= dest %>
 TMPFILE=`mktemp`

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -7,7 +7,7 @@ echo "BEGIN EFS BACKUP: `date`"
 #     "mount_path": "/mnt/ca-integrations/boomi-test",
 #     "efs_id": "fs-ab74bde2",
 #     "backup_s3bucket_name": "cu-cloud-devops-boomi",
-#     "backup_s3bucket_prefix:": "efs-backups"
+#     "backup_s3bucket_prefix": "efs-backups"
 #   }
 # ]
 <%

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -14,7 +14,7 @@ exec 2>&1
 # <%= src %> ==> <%= dest %>
 TMPFILE=`mktemp`
 echo "BEGIN SYNC: `date`" > $TMPFILE
-s3cmd sync --dry-run --verbose --ssl --check-md5 --delete-removed --preserve <%= src %> <%= dest%> >> TMPFILE 2>&1 $
+s3cmd sync --dry-run --verbose --ssl --check-md5 --delete-removed --preserve <%= src %> <%= dest%> >> $TMPFILE 2>&1
 cat $TMPFILE >> <%= logfile %>
 rm $TMPFILE
 s3cmd put --dry-run --verbose --ssl --preserve <%= logfile %> <%= dest%>

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -17,7 +17,7 @@ echo "BEGIN EFS BACKUP: `date`"
 
   src = "#{backup['mount_path']}/"
   prefix = backup['backup_s3bucket_prefix']
-  dest = "s3://#{bucket_name}/#{prefix}/#{efs['efs_id']}/"
+  dest = "s3://#{bucket_name}/#{prefix}/#{backup['efs_id']}/"
   logfile = src + 'efs-backup.log'
 %>
 # <%= src %> ==> <%= dest %>

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -18,15 +18,17 @@ echo "BEGIN EFS BACKUP: `date`"
   src = "#{backup['mount_path']}/"
   dest = "s3://#{bucket_name}/#{backup['backup_s3bucket_prefix']}/#{backup['efs_id']}/"
   logfile = src + 'efs-backup.log'
+  dry_run = (backup['backup_dry_run'] ? '--dry-run' : '')
+  verbose = (backup['backup_verbose'] ? '--verbose' : '')
 %>
 # <%= src %> ==> <%= dest %>
 TMPFILE=`mktemp`
 echo "BEGIN SYNC: `date`" > $TMPFILE
-s3cmd sync --dry-run --verbose --ssl --check-md5 --delete-removed --preserve <%= src %> <%= dest%> >> $TMPFILE 2>&1
+s3cmd sync <%= dry_run %> <%= verbose %> --ssl --check-md5 --delete-removed --preserve <%= src %> <%= dest%> >> $TMPFILE 2>&1
 echo "END SYNC: `date`" >> $TMPFILE
 cat $TMPFILE >> <%= logfile %>
 rm $TMPFILE
-s3cmd put --dry-run --verbose --ssl --preserve <%= logfile %> <%= dest%>
+s3cmd put <%= dry_run %> <%= verbose %> --ssl --preserve <%= logfile %> <%= dest%>
 
 <%
 end

--- a/cd-efs/templates/s3backup/efs-backup.sh.erb
+++ b/cd-efs/templates/s3backup/efs-backup.sh.erb
@@ -14,7 +14,7 @@ exec 2>&1
 # <%= src %> ==> <%= dest %>
 TMPFILE=`mktemp`
 echo "BEGIN SYNC: `date`" > $TMPFILE
-s3cmd sync --dry-run --verbose --ssl --check-md5 --delete-removed --preserve <%= src %> <%= dest%> 2>&1 $TMPFILE
+s3cmd sync --dry-run --verbose --ssl --check-md5 --delete-removed --preserve <%= src %> <%= dest%> >> TMPFILE 2>&1 $
 cat $TMPFILE >> <%= logfile %>
 rm $TMPFILE
 s3cmd put --dry-run --verbose --ssl --preserve <%= logfile %> <%= dest%>


### PR DESCRIPTION
Add cd-efs::s3backups recipe that uses s3cmd support for configuring cron-based backups of EFS to S3.